### PR TITLE
Add configurable status file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ export default {
 	verbose				: true, // Whether or not to output pulse messages in the console
 	readableStatusJson	: true, // Format status.json to be human readable
 	logsMaxDatapoints	: 200, // Maximum datapoints history to keep (per endpoint)
+       statusFile                      : './static/status.json', // Path to status.json file. Dashboard path auto-written to static/client-config.js
 	telegram			: {}, // optional, tokens to send notifications through telegram
 	slack				: {}, // optional, tokens to send notifications through slack
 	discord				: {}, // optional, tokens to send notifications through discord
@@ -93,7 +94,7 @@ pm2 save
 ```
 
 ### Serving the status page
-The `watcher.js` script only takes care of running the status checks and updates the `status.json` file in the `static/` folder. If you want to view the final result, you simply need to serve the files in the `static/` folder. You can use Nginx with a config like:
+The `watcher.js` script only takes care of running the status checks and updates the file defined by `statusFile` (by default `static/status.json`). It also writes the relative location to `static/client-config.js` so the dashboard knows where to fetch the status file. If you want to view the final result, you simply need to serve the files in the `static/` folder (or wherever your dashboard points to). You can use Nginx with a config like:
 ```nginx
 # Pulse
 server {

--- a/config.js
+++ b/config.js
@@ -7,6 +7,7 @@ export default {
 	verbose				: true, // Whether or not to output pulse messages in the console
 	readableStatusJson	: true, // Format status.json to be human readable
 	logsMaxDatapoints	: 200, // Maximum datapoints history to keep (per endpoint)
+	statusFile					: './static/status.json', // Path to status.json file
 	telegram			: { // optional, tokens to send notifications through telegram
 		botToken	: '', // Contact @BotFather on telegram to create a bot
 		chatId		: '',// Send a message to the bot, then visit https://api.telegram.org/bot<token>/getUpdates to get the chatId

--- a/static/client-config.js
+++ b/static/client-config.js
@@ -1,0 +1,1 @@
+window.statusFile = './status.json';

--- a/static/client.js
+++ b/static/client.js
@@ -1,14 +1,15 @@
 let config;
 let lastPulse = 0;
+const STATUS_FILE = window.statusFile || './status.json';
 const setError = (text)=>{document.querySelector('error-notice').innerText = text;};
 document.addEventListener("DOMContentLoaded", async () => {
 	let $main = document.querySelector('main');
 	const refreshStatus = async () => {
-		try {
-			const response = await fetch('./status.json', {cache: "no-cache"});
-			if (!response.ok) {
-				throw new Error(`Error fetching status.json: ${response.statusText}`);
-			}
+               try {
+                        const response = await fetch(STATUS_FILE, {cache: "no-cache"});
+                        if (!response.ok) {
+                                throw new Error(`Error fetching status file: ${response.statusText}`);
+                        }
 			setError(''); // Clear errors
 			const status = await response.json();
 			$main.innerHTML = '';

--- a/static/index.html
+++ b/static/index.html
@@ -9,8 +9,9 @@
 		<link href="style.css" rel="stylesheet" />
 		<link rel="preconnect" href="https://fonts.googleapis.com">
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-		<link href="https://fonts.googleapis.com/css2?family=Fira+Sans+Condensed:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,200,0,0&display=swap" rel="stylesheet">
-		<script src="client.js" type="text/javascript"></script>
+                <link href="https://fonts.googleapis.com/css2?family=Fira+Sans+Condensed:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,200,0,0&display=swap" rel="stylesheet">
+                <script src="client-config.js"></script>
+                <script src="client.js" type="text/javascript"></script>
 	</head>
 	<body>
 		<header>


### PR DESCRIPTION
## Summary
- allow customizing path to status.json
- provide path to dashboard via client-config.js
- update client.js and index.html to use generated path

## Testing
- `npm test` *(fails: Error: no test specified)*