### PR TITLE
Add configurable status file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Visit https://apulse.ybouane.com for a demo!
 - Check content for validity, HTTP status...
 - Measures latency
 - Minimal and easy to use dashboard
-- Easy to setup. Run the watcher.js script and open the static/index.html page to view the dashboard.
+- Easy to setup. Run the `entrypoint.sh` script and open the static/index.html page to view the dashboard.
 - Auto-reload of the config file (no need to restart the watcher)
 - No dependencies
 
@@ -30,6 +30,7 @@ export default {
 	verbose				: true, // Whether or not to output pulse messages in the console
 	readableStatusJson	: true, // Format status.json to be human readable
 	logsMaxDatapoints	: 200, // Maximum datapoints history to keep (per endpoint)
+        statusFile                      : './static/status.json', // Path to status.json file
 	telegram			: {}, // optional, tokens to send notifications through telegram
 	slack				: {}, // optional, tokens to send notifications through slack
 	discord				: {}, // optional, tokens to send notifications through discord
@@ -67,12 +68,12 @@ Clone the repo:
 git clone https://github.com/ybouane/aPulse.git
 ```
 
-Either run the watcher.js script directly (you need to keep it running in the background)
+Either run the entrypoint.sh script directly (you need to keep it running in the background)
 ```shell
 cd aPulse
 ```
 ```shell
-node watcher.js
+./entrypoint.sh
 ```
 
 Or use a tool like PM2 (prefered method):
@@ -93,7 +94,7 @@ pm2 save
 ```
 
 ### Serving the status page
-The `watcher.js` script only takes care of running the status checks and updates the `status.json` file in the `static/` folder. If you want to view the final result, you simply need to serve the files in the `static/` folder. You can use Nginx with a config like:
+The `watcher.js` script only takes care of running the status checks and updates the file defined by `statusFile` (by default `static/status.json`). The `entrypoint.sh` script patches `static/client.js` with this path before starting `watcher.js`. If you want to view the final result, you simply need to serve the files in the `static/` folder (or wherever your dashboard points to). You can use Nginx with a config like:
 ```nginx
 # Pulse
 server {

--- a/config.js
+++ b/config.js
@@ -7,6 +7,7 @@ export default {
 	verbose				: true, // Whether or not to output pulse messages in the console
 	readableStatusJson	: true, // Format status.json to be human readable
 	logsMaxDatapoints	: 200, // Maximum datapoints history to keep (per endpoint)
+	statusFile					: './static/status.json', // Path to status.json file
 	telegram			: { // optional, tokens to send notifications through telegram
 		botToken	: '', // Contact @BotFather on telegram to create a bot
 		chatId		: '',// Send a message to the bot, then visit https://api.telegram.org/bot<token>/getUpdates to get the chatId

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+STATUS_FILE=$(node - <<'NODE'
+import config from './config.js';
+console.log(config.statusFile || './static/status.json');
+NODE
+)
+ESC_PATH=$(printf '%s\n' "$STATUS_FILE" | sed 's/[&/]/\\&/g')
+sed -i -E "s|(fetch\(['\"])(\.\/status\.json)(['\"])|\1${ESC_PATH}\3|" static/client.js
+exec node watcher.js
+

--- a/pm2.json
+++ b/pm2.json
@@ -1,6 +1,6 @@
 {
 	"apps": [{
 		"name"			: "aPulse",
-		"script"		: "./watcher.js"
+		"script"                : "./entrypoint.sh"
 	}]
 }

--- a/watcher.js
+++ b/watcher.js
@@ -1,16 +1,16 @@
 import {promises as fs, watchFile} from 'fs';
 let config = (await import('./config.js')).default;
+let statusFile = config.statusFile || './static/status.json';
 
 watchFile('./config.js', async ()=>{ // Dynamically reload config and watch it for changes.
-	try {
-		config = (await import('./config.js?refresh='+Date.now())).default;
-		console.log('Reloaded config file.')
-	} catch(e) {
-		console.error(e);
-	}
+       try {
+               config = (await import('./config.js?refresh='+Date.now())).default;
+               statusFile = config.statusFile || './static/status.json';
+               console.log('Reloaded config file.')
+       } catch(e) {
+               console.error(e);
+       }
 });
-
-const statusFile = './static/status.json';
 
 const delay  = async t=>new Promise(r=>setTimeout(r, t));
 const handlize = s=>s.toLowerCase().replace(/[^a-z0-9]/g, ' ').trim().replace(/\s+/g, '-');


### PR DESCRIPTION
## Summary
- allow customizing path to `status.json`
- document `statusFile` setting
- added entrypoint script to patch `client.js` on startup

## Testing
- `npm test` *(fails: Error: no test specified)*